### PR TITLE
chore(core): Bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 0.2.1
+## 0.3.0
 - Dry run is now enabled by default for safety. Turn off in settings to perform actual deletion.
+- List target journal dates in the dry run toast and developer console.
+- Show dry run results as a persistent warning toast with instructions for performing the actual deletion.
+- Lowered the default "Days to look back" from 30 to 10.
 
 ## 0.2.0
 - Added Days to look back setting to limit the scan range.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logseq-clean-journals",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logseq-clean-journals",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@logseq/libs": "^0.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-clean-journals",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Automatically removes empty journal pages from your Logseq graph with a single toolbar click.",
   "author": "Rino",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Prepare 0.3.0 release.

## Changes
- Bump `version` in `package.json` to 0.3.0
- Sync `package-lock.json`
- Update `CHANGELOG.md`:
  - Dry run is now enabled by default for safety. Turn off in settings to perform actual deletion.
  - List target journal dates in the dry run toast and developer console.
  - Show dry run results as a persistent warning toast with instructions for performing the actual deletion.
  - Lowered the default "Days to look back" from 30 to 10.

## Note
The previous unreleased changes were tentatively labeled 0.2.1 in CHANGELOG.
Bumping to 0.3.0 to reflect the user-visible behavior changes (dry run default ON, larger UX changes).