### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 0.2.1
+## 0.3.0
 - Dry run is now enabled by default for safety. Turn off in settings to perform actual deletion.
+- List target journal dates in the dry run toast and developer console.
+- Show dry run results as a persistent warning toast with instructions for performing the actual deletion.
+- Lowered the default "Days to look back" from 30 to 10.
 
 ## 0.2.0
 - Added Days to look back setting to limit the scan range.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.1
+- Dry run is now enabled by default for safety. Turn off in settings to perform actual deletion.
+
 ## 0.2.0
 - Added Days to look back setting to limit the scan range.
 - Added Dry run mode.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Click the trash-can icon in the toolbar. A notification will confirm how many em
 | Setting           | Default | Description                                                        |
 | ----------------- | ------- | ------------------------------------------------------------------ |
 | Days to look back | `30`    | Number of past days to scan. Set to `0` to scan all journal pages. |
-| Dry run           | `false` | When enabled, counts empty journals without deleting them.         |
+| Dry run           | `true`  | Counts empty journals without deleting them. Turn off to actually delete. |
 
 Settings are accessible via Logseq → `...` → Plugins → Clean Empty Journals → Settings.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logseq-clean-journals",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logseq-clean-journals",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@logseq/libs": "^0.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-clean-journals",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Automatically removes empty journal pages from your Logseq graph with a single toolbar click.",
   "author": "Rino",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-clean-journals",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Automatically removes empty journal pages from your Logseq graph with a single toolbar click.",
   "author": "Rino",
   "license": "MIT",

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import "@logseq/libs";
 async function deleteEmptyJournals() {
   const settings = logseq.settings || {};
   const daysBack = parseInt(settings.daysBack ?? 30, 10) || 0;
-  const dryRun = settings.dryRun ?? false;
+  const dryRun = settings.dryRun ?? true;
 
   const today = new Date();
   const todayStr = today.toISOString().slice(0, 10);
@@ -57,9 +57,9 @@ function main() {
     {
       key: "dryRun",
       type: "boolean",
-      default: false,
+      default: true,
       title: "Dry run",
-      description: "If enabled, only counts empty journals without deleting them.",
+      description: "If enabled, only counts empty journals without deleting them. Turn off to actually delete.",
     },
   ]);
 

--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,7 @@ async function deleteEmptyJournals() {
     if (count > 0) {
       const list = targets.map((n) => `- ${n}`).join("\n");
       logseq.App.showMsg(
-        `⚠️ DRY RUN MODE — Nothing was deleted.\n\n` +
+        `DRY RUN MODE. Nothing was deleted.\n\n` +
           `${count} empty journal(s) would be deleted${rangeLabel}:\n` +
           `${list}\n\n` +
           `To actually delete, uncheck "Dry run" in plugin settings.`,
@@ -59,7 +59,7 @@ async function deleteEmptyJournals() {
       );
     } else {
       logseq.App.showMsg(
-        `⚠️ DRY RUN MODE — Nothing was deleted.\n\n` +
+        `DRY RUN MODE. Nothing was deleted.\n\n` +
           `No empty journals found${rangeLabel}.`,
         "warning",
         { timeout: 0 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import "@logseq/libs";
 
 async function deleteEmptyJournals() {
   const settings = logseq.settings || {};
-  const daysBack = parseInt(settings.daysBack ?? 30, 10) || 0;
+  const daysBack = parseInt(settings.daysBack ?? 10, 10) || 0;
   const dryRun = settings.dryRun ?? false;
 
   const today = new Date();
@@ -23,7 +23,7 @@ async function deleteEmptyJournals() {
     return true;
   });
 
-  let count = 0;
+  const targets = [];
   for (const page of journals) {
     const blocks = await logseq.Editor.getPageBlocksTree(page.name);
     const isEmpty =
@@ -32,17 +32,47 @@ async function deleteEmptyJournals() {
       (blocks.length === 1 && (!blocks[0].content || blocks[0].content.trim() === ""));
     if (isEmpty) {
       if (!dryRun) await logseq.Editor.deletePage(page.name);
-      count++;
+      targets.push(page.name);
     }
   }
 
+  const count = targets.length;
   const rangeLabel = daysBack > 0 ? ` (last ${daysBack} days)` : "";
-  const dryLabel = dryRun ? " [Dry run]" : "";
-  logseq.App.showMsg(
-    count > 0
-      ? `${dryLabel}Deleted ${count} empty journal(s)${rangeLabel}.`
-      : `${dryLabel}No empty journals found${rangeLabel}.`
-  );
+
+  console.group("[logseq-clean-journals]");
+  console.log(`Mode: ${dryRun ? "Dry run" : "Delete"}`);
+  console.log(`Range: ${daysBack > 0 ? `last ${daysBack} days` : "all"}`);
+  console.log(`Target count: ${count}`);
+  if (count > 0) console.log("Targets:", targets);
+  console.groupEnd();
+
+  if (dryRun) {
+    if (count > 0) {
+      const list = targets.map((n) => `- ${n}`).join("\n");
+      logseq.App.showMsg(
+        `⚠️ DRY RUN MODE — Nothing was deleted.\n\n` +
+          `${count} empty journal(s) would be deleted${rangeLabel}:\n` +
+          `${list}\n\n` +
+          `To actually delete, uncheck "Dry run" in plugin settings.`,
+        "warning",
+        { timeout: 0 }
+      );
+    } else {
+      logseq.App.showMsg(
+        `⚠️ DRY RUN MODE — Nothing was deleted.\n\n` +
+          `No empty journals found${rangeLabel}.`,
+        "warning",
+        { timeout: 0 }
+      );
+    }
+  } else {
+    logseq.App.showMsg(
+      count > 0
+        ? `Deleted ${count} empty journal(s)${rangeLabel}.`
+        : `No empty journals found${rangeLabel}.`,
+      "success"
+    );
+  }
 }
 
 function main() {
@@ -50,7 +80,7 @@ function main() {
     {
       key: "daysBack",
       type: "number",
-      default: 30,
+      default: 10,
       title: "Days to look back",
       description: "How many past days to scan for empty journals. Set to 0 to scan all.",
     },


### PR DESCRIPTION
## v0.3.0

Release of accumulated changes from `dev` into `main`.

### Highlights
- Dry run is now enabled by default for safety. Turn off in settings to perform actual deletion.
- List target journal dates in the dry run toast and developer console.
- Show dry run results as a persistent warning toast with instructions for performing the actual deletion.
- Lowered the default "Days to look back" from 30 to 10.

See `CHANGELOG.md` for details.