### PR TITLE
docs(core): Fix outdated default for Days to look back

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Click the trash-can icon in the toolbar. A notification will confirm how many em
 
 | Setting           | Default | Description                                                        |
 | ----------------- | ------- | ------------------------------------------------------------------ |
-| Days to look back | `30`    | Number of past days to scan. Set to `0` to scan all journal pages. |
+| Days to look back | `10`    | Number of past days to scan. Set to `0` to scan all journal pages. |
 | Dry run           | `true`  | Counts empty journals without deleting them. Turn off to actually delete. |
 
 Settings are accessible via Logseq → `...` → Plugins → Clean Empty Journals → Settings.


### PR DESCRIPTION
Update the Settings table in README to reflect the current default (10 days). The default was lowered from 30 to 10 in v0.3.0 but the README still showed the old value.